### PR TITLE
Feature/gorilla mux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 .glide/
 
 .dev
+.idea

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.16
 
 require (
 	github.com/fatih/color v1.12.0
+	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/nmrshll/rndm-go v0.0.0-20170430161430-8da3024e53de
 	github.com/palantir/stacktrace v0.0.0-20161112013806-78658fd2d177
 	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966

--- a/go.sum
+++ b/go.sum
@@ -97,6 +97,8 @@ github.com/google/pprof v0.0.0-20200708004538-1a94d8640e99/go.mod h1:ZgVRPoUq/hf
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
+github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
+github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=

--- a/oauth2ns.go
+++ b/oauth2ns.go
@@ -77,7 +77,7 @@ func AuthenticateUser(oauthConfig *oauth2.Config, appConfig Config, options ...A
 
 	// Redirect user to consent page to ask for permission
 	// for the scopes specified above.
-	oauthConfig.RedirectURL = fmt.Sprintf("http://%s:%s/%s",
+	oauthConfig.RedirectURL = fmt.Sprintf("http://%s:%s%s",
 		"localhost",
 		strconv.Itoa(appConfig.Port),
 		appConfig.Path,
@@ -143,7 +143,7 @@ func startHTTPServer(ctx context.Context, conf *oauth2.Config, appConfig Config)
 	stopHTTPServerChan = make(chan struct{})
 	cancelAuthentication = make(chan struct{})
 
-	http.HandleFunc("/oauth/callback", callbackHandler(ctx, conf, clientChan,appConfig))
+	http.HandleFunc(fmt.Sprintf("%s",appConfig.Path), callbackHandler(ctx, conf, clientChan,appConfig))
 	srv := &http.Server{Addr: ":" + strconv.Itoa(appConfig.Port)}
 
 	// handle server shutdown signal

--- a/oauth2ns.go
+++ b/oauth2ns.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"github.com/gorilla/mux"
 	"log"
 	"net/http"
 	"net/url"
@@ -143,8 +144,9 @@ func startHTTPServer(ctx context.Context, conf *oauth2.Config, appConfig Config)
 	stopHTTPServerChan = make(chan struct{})
 	cancelAuthentication = make(chan struct{})
 
-	http.HandleFunc(fmt.Sprintf("%s",appConfig.Path), callbackHandler(ctx, conf, clientChan,appConfig))
-	srv := &http.Server{Addr: ":" + strconv.Itoa(appConfig.Port)}
+	router := mux.NewRouter()
+	router.HandleFunc(appConfig.Path, callbackHandler(ctx, conf, clientChan,appConfig))
+	srv := &http.Server{Addr: ":" + strconv.Itoa(appConfig.Port), Handler: router}
 
 	// handle server shutdown signal
 	go func() {

--- a/oauth2ns.go
+++ b/oauth2ns.go
@@ -40,6 +40,8 @@ type Config struct {
 	Port int `yaml:"port" json:"port"`
 	Timeout int `yaml:"timeout" json:"timeout"`
 	StateStringContextKey int `yaml:"state-string-context-key" json:"state-string-context-key"`
+	//Path is the callback URL to mount on the listener
+	Path string `yaml:"path" json:"path"`
 }
 
 type AuthenticateUserOption func(*AuthenticateUserFuncConfig) error
@@ -75,7 +77,11 @@ func AuthenticateUser(oauthConfig *oauth2.Config, appConfig Config, options ...A
 
 	// Redirect user to consent page to ask for permission
 	// for the scopes specified above.
-	oauthConfig.RedirectURL = fmt.Sprintf("http://%s:%s/oauth/callback", "localhost", strconv.Itoa(appConfig.Port))
+	oauthConfig.RedirectURL = fmt.Sprintf("http://%s:%s/%s",
+		"localhost",
+		strconv.Itoa(appConfig.Port),
+		appConfig.Path,
+	)
 
 	// Some random string, random for each request
 	oauthStateString := rndm.String(8)


### PR DESCRIPTION
Adding gorilla mux into the StartHttpServer function to avoid using global `http` handler. Should avoid panics for secondary registration attempts for multiple registrations during runtime. 